### PR TITLE
Align long option for priority with help string

### DIFF
--- a/src/cyclictest/cyclictest.c
+++ b/src/cyclictest/cyclictest.c
@@ -1064,7 +1064,7 @@ static void process_options (int argc, char *argv[])
 			{"nanosleep", no_argument, NULL, 'n'},
 			{"nsecs", no_argument, NULL, 'N'},
 			{"oscope", required_argument, NULL, 'o'},
-			{"priority", required_argument, NULL, 'p'},
+			{"prio", required_argument, NULL, 'p'},
                         {"policy", required_argument, NULL, 'y'},
 			{"preemptoff", no_argument, NULL, 'P'},
 			{"quiet", no_argument, NULL, 'q'},


### PR DESCRIPTION
Currently, the help string specifies the long option for priority with `--prio`. However, when processing the command line options in the `process_options` method, it looks for `--priority`. 

This PR fixes this by using the same long option as in the help string.