### PR TITLE
Cyclictests cleanup make work with new kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 CFLAGS ?= -D_GNU_SOURCE -Wall -Wno-nonnull -Isrc/include
 LDFLAGS ?=
 
-PYLIB  := $(shell python -c 'import distutils.sysconfig;  print distutils.sysconfig.get_python_lib()')
+PYLIB  := $(shell python2 -c 'import distutils.sysconfig;  print distutils.sysconfig.get_python_lib()')
 
 ifndef DEBUG
 	CFLAGS	+= -O2

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifneq ($(filter x86_64 i386 ia64 mips powerpc,$(machinetype)),)
 NUMA 	:= 1
 endif
 
-CFLAGS ?= -D_GNU_SOURCE -Wall -Wno-nonnull -Isrc/include
+CFLAGS ?= -D_GNU_SOURCE -Wall -Wno-nonnull -Wno-unused-result -Isrc/include
 LDFLAGS ?=
 
 PYLIB  := $(shell python2 -c 'import distutils.sysconfig;  print distutils.sysconfig.get_python_lib()')

--- a/src/pmqtest/pmqtest.c
+++ b/src/pmqtest/pmqtest.c
@@ -45,9 +45,10 @@
 
 #define USEC_PER_SEC 1000000
 
-#define SYNCMQ_NAME "/syncmsg%d"
-#define TESTMQ_NAME "/testmsg%d"
-#define MSG_SIZE 8
+#define SYNCMQ_NAME "/syncmsg%010d"
+#define TESTMQ_NAME "/testmsg%010d"
+#define MSG_SIZE 8 
+#define SIZEOF_MQNAME 19
 #define MSEC_PER_SEC 1000
 #define NSEC_PER_SEC 1000000000
 
@@ -358,13 +359,10 @@ static void process_options (int argc, char *argv[])
 		}
 	}
 
-	if (num_threads < 0 || num_threads > 255)
+	if (num_threads < 1 || num_threads > 255)
 		error = 1;
 
 	if (priority < 0 || priority > 99)
-		error = 1;
-
-	if (num_threads < 1)
 		error = 1;
 
 	if (forcetimeout && !timeout)
@@ -429,7 +427,7 @@ int main(int argc, char *argv[])
 		goto nomem;
 
 	for (i = 0; i < num_threads; i++) {
-		char mqname[16];
+		char mqname[SIZEOF_MQNAME];
 
 		sprintf(mqname, SYNCMQ_NAME, i);
 		receiver[i].syncmq = mq_open(mqname, oflag, 0777, &mqstat);
@@ -512,12 +510,12 @@ int main(int argc, char *argv[])
 					(int) ((receiver[i].sumdiff / receiver[i].samples) + 0.5),
 					receiver[i].maxdiff);
 				if (receiver[i].error[0] != '\0') {
-					printf(receiver[i].error);
+					printf("%s", receiver[i].error);
 					errorlines++;
 					receiver[i].error[0] = '\0';
 				}
 				if (sender[i].error[0] != '\0') {
-					printf(sender[i].error);
+					printf("%s", sender[i].error);
 					errorlines++;
 					receiver[i].error[0] = '\0';
 				}
@@ -556,7 +554,7 @@ int main(int argc, char *argv[])
 	}
 	nanosleep(&maindelay, NULL);
 	for (i = 0; i < num_threads; i++) {
-		char mqname[16];
+		char mqname[SIZEOF_MQNAME];
 
 		mq_close(receiver[i].syncmq);
 		sprintf(mqname, SYNCMQ_NAME, i);

--- a/src/ptsematest/ptsematest.c
+++ b/src/ptsematest/ptsematest.c
@@ -137,7 +137,7 @@ void *semathread(void *param)
 				int tracing_enabled =
 				    open(tracing_enabled_file, O_WRONLY);
 				if (tracing_enabled >= 0) {
-					write(tracing_enabled, "0", 1);
+				    write(tracing_enabled, "0", 1);
 					close(tracing_enabled);
 				} else
 					snprintf(par->error, sizeof(par->error),
@@ -389,12 +389,12 @@ int main(int argc, char *argv[])
 					(int) ((receiver[i].sumdiff / receiver[i].samples) + 0.5),
 					receiver[i].maxdiff);
 				if (receiver[i].error[0] != '\0') {
-					printf(receiver[i].error);
+					printf("%s", receiver[i].error);
 					errorlines++;
 					receiver[i].error[0] = '\0';
 				}
 				if (sender[i].error[0] != '\0') {
-					printf(sender[i].error);
+					printf("%s", sender[i].error);
 					errorlines++;
 					receiver[i].error[0] = '\0';
 				}

--- a/src/sigwaittest/sigwaittest.c
+++ b/src/sigwaittest/sigwaittest.c
@@ -346,7 +346,7 @@ int main(int argc, char *argv[])
 	struct params *sender = NULL;
 	sigset_t sigset;
 	void *param = NULL;
-	char f_opt[8];
+	char f_opt[15];
 	struct timespec launchdelay, maindelay;
 
 	process_options(argc, argv);
@@ -561,12 +561,12 @@ int main(int argc, char *argv[])
 					    receiver[i].samples) + 0.5),
 					    receiver[i].maxdiff);
 				if (receiver[i].error[0] != '\0') {
-					printf(receiver[i].error);
+					printf("%s", receiver[i].error);
 					receiver[i].error[0] = '\0';
 					errorlines++;
 				}
 				if (sender[i].error[0] != '\0') {
-					printf(sender[i].error);
+					printf("%s", sender[i].error);
 					sender[i].error[0] = '\0';
 					errorlines++;
 				}

--- a/src/svsematest/svsematest.c
+++ b/src/svsematest/svsematest.c
@@ -395,7 +395,7 @@ int main(int argc, char *argv[])
 	struct params *sender = NULL;
 	sigset_t sigset;
 	void *param = NULL;
-	char f_opt[8];
+	char f_opt[15];
 	struct timespec launchdelay, maindelay;
 
 	myfile = getenv("_");
@@ -646,12 +646,12 @@ int main(int argc, char *argv[])
 					    receiver[i].samples) + 0.5),
 					    receiver[i].maxdiff);
 				if (receiver[i].error[0] != '\0') {
-					printf(receiver[i].error);
+					printf("%s", receiver[i].error);
 					receiver[i].error[0] = '\0';
 					errorlines++;
 				}
 				if (sender[i].error[0] != '\0') {
-					printf(sender[i].error);
+					printf("%s", sender[i].error);
 					sender[i].error[0] = '\0';
 					errorlines++;
 				}


### PR DESCRIPTION
Hey, I had need for some RT testing utils recently, and found these somewhat bitrotted but still quite valuable. I got them to compile with a modern kernel and dropped support for everything else. These tracing tools have been around for 10-20 years, which should have been plenty of time to design an API around this stuff.

I then dealt with a bunch of GCC warnings, a few pedantries, as well as some potential buffer overflows.  All of the utilities at least compile and run for 20-30 seconds without crashing. The testing gets sparser as you move away from cyclictest.

I have a few more RT primitives that I'd like to add coverage for, namely, using pthread synchronization primitives along with memlock()ed shared memory for IPC, and I discovered some cool RT-relevant things about how pthreads are implemented that I never had time to follow through on